### PR TITLE
SQS: Support both Query & JSON SQS Protocols for Async

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -60,6 +60,7 @@ Gregory Haskins <greg@greghaskins.com>
 Hank John <jindongh@gmail.com>
 haridsv
 Hong Minhee <minhee@dahlia.kr>
+Hunter Fernandes <hunter@hfernandes.com>
 Ian Eure <ian.eure@gmail.com>
 Ian Struble <istruble@gmail.com>
 Ionel Maries Cristian <contact@ionelmc.ro>

--- a/kombu/asynchronous/aws/connection.py
+++ b/kombu/asynchronous/aws/connection.py
@@ -183,8 +183,8 @@ class AsyncAWSQueryConnection(AsyncConnection):
         super().__init__(sqs_connection, http_client,
                          **http_client_params)
 
-    def make_request(self, operation, params_, path, verb, callback=None):
-        params = params_.copy()
+    def make_request(self, operation, params_, path, verb, callback=None, protocol_params=None):
+        params = params_.copy() | (protocol_params or {}).get('query', {})
         if operation:
             params['Action'] = operation
         signer = self.sqs_connection._request_signer
@@ -203,29 +203,33 @@ class AsyncAWSQueryConnection(AsyncConnection):
 
         return self._mexe(prepared_request, callback=callback)
 
-    def get_list(self, operation, params, markers, path='/', parent=None, verb='POST', callback=None):
+    def get_list(self, operation, params, markers, path='/', parent=None, verb='POST', callback=None,
+                 protocol_params=None):
         return self.make_request(
             operation, params, path, verb,
             callback=transform(
                 self._on_list_ready, callback, parent or self, markers,
                 operation
             ),
+            protocol_params=protocol_params,
         )
 
-    def get_object(self, operation, params, path='/', parent=None, verb='GET', callback=None):
+    def get_object(self, operation, params, path='/', parent=None, verb='GET', callback=None, protocol_params=None):
         return self.make_request(
             operation, params, path, verb,
             callback=transform(
                 self._on_obj_ready, callback, parent or self, operation
             ),
+            protocol_params=protocol_params,
         )
 
-    def get_status(self, operation, params, path='/', parent=None, verb='GET', callback=None):
+    def get_status(self, operation, params, path='/', parent=None, verb='GET', callback=None, protocol_params=None):
         return self.make_request(
             operation, params, path, verb,
             callback=transform(
                 self._on_status_ready, callback, parent or self, operation
             ),
+            protocol_params=protocol_params,
         )
 
     def _on_list_ready(self, parent, markers, operation, response):

--- a/kombu/asynchronous/aws/sqs/connection.py
+++ b/kombu/asynchronous/aws/sqs/connection.py
@@ -76,25 +76,29 @@ class AsyncSQSConnection(AsyncAWSQueryConnection):
             **param_payload
         )
 
-    def make_request(self, operation_name, params, queue_url, verb, callback=None):
+    def make_request(self, operation_name, params, queue_url, verb, callback=None, protocol_params=None):
         """Override make_request to support different protocols.
 
-        botocore is soon going to change the default protocol of communicating
+        botocore has changed the default protocol of communicating
         with SQS backend from 'query' to 'json', so we need a special
         implementation of make_request for SQS. More information on this can
         be found in: https://github.com/celery/kombu/pull/1807.
+
+        protocol_params: Optional[dict[str, dict] of per-protocol additional parameters.
+            Supported for the SQS query to json protocol transition.
         """
         signer = self.sqs_connection._request_signer
 
         service_model = self.sqs_connection.meta.service_model
         protocol = service_model.protocol
+        all_params = (params or {}) | protocol_params.get(protocol, {})
 
         if protocol == 'query':
             request = self._create_query_request(
-                operation_name, params, queue_url, verb)
+                operation_name, all_params, queue_url, verb)
         elif protocol == 'json':
             request = self._create_json_request(
-                operation_name, params, queue_url)
+                operation_name, all_params, queue_url)
         else:
             raise Exception(f'Unsupported protocol: {protocol}.')
 
@@ -133,8 +137,12 @@ class AsyncSQSConnection(AsyncAWSQueryConnection):
     def set_queue_attribute(self, queue, attribute, value, callback=None):
         return self.get_status(
             'SetQueueAttribute',
-            {'Attribute.Name': attribute, 'Attribute.Value': value},
+            {},
             queue.id, callback=callback,
+            protocol_params={
+                'json': {'Attributes': {attribute: value}},
+                'query': {'Attribute.Name': attribute, 'Attribute.Value': value},
+            },
         )
 
     def receive_message(
@@ -143,18 +151,20 @@ class AsyncSQSConnection(AsyncAWSQueryConnection):
         callback=None
     ):
         params = {'MaxNumberOfMessages': number_messages}
+        proto_params = {'query': {}, 'json': {}}
+
         if visibility_timeout:
             params['VisibilityTimeout'] = visibility_timeout
         if attributes:
-            attrs = {}
-            for idx, attr in enumerate(attributes):
-                attrs['AttributeName.' + str(idx + 1)] = attr
-            params.update(attrs)
+            proto_params['json'].update({'AttributeNames': list(attributes)})
+            proto_params['query'].update(_query_object_encode({'AttributeName': list(attributes)}))
         if wait_time_seconds is not None:
             params['WaitTimeSeconds'] = wait_time_seconds
+
         return self.get_list(
             'ReceiveMessage', params, [('Message', AsyncMessage)],
             queue_url, callback=callback, parent=queue,
+            protocol_params=proto_params,
         )
 
     def delete_message(self, queue, receipt_handle, callback=None):
@@ -163,16 +173,21 @@ class AsyncSQSConnection(AsyncAWSQueryConnection):
         )
 
     def delete_message_batch(self, queue, messages, callback=None):
-        params = {}
-        for i, m in enumerate(messages):
-            prefix = f'DeleteMessageBatchRequestEntry.{i + 1}'
-            params.update({
-                f'{prefix}.Id': m.id,
-                f'{prefix}.ReceiptHandle': m.receipt_handle,
-            })
+        p_params = {
+            'json': {
+                'Entries': [{'Id': m.id, 'ReceiptHandle': m.receipt_handle} for m in messages],
+            },
+            'query': _query_object_encode({
+                'DeleteMessageBatchRequestEntry': [
+                    {'Id': m.id, 'ReceiptHandle': m.receipt_handle}
+                    for m in messages
+                ],
+            }),
+        }
+
         return self.get_object(
-            'DeleteMessageBatch', params, queue.id,
-            verb='POST', callback=callback,
+            'DeleteMessageBatch', {}, queue.id,
+            verb='POST', callback=callback, protocol_params=p_params,
         )
 
     def delete_message_from_handle(self, queue, receipt_handle,
@@ -216,17 +231,20 @@ class AsyncSQSConnection(AsyncAWSQueryConnection):
         )
 
     def change_message_visibility_batch(self, queue, messages, callback=None):
-        params = {}
-        for i, t in enumerate(messages):
-            pre = f'ChangeMessageVisibilityBatchRequestEntry.{i + 1}'
-            params.update({
-                f'{pre}.Id': t[0].id,
-                f'{pre}.ReceiptHandle': t[0].receipt_handle,
-                f'{pre}.VisibilityTimeout': t[1],
-            })
+        entries = [
+            {'Id': t[0].id, 'ReceiptHandle': t[0].receipt_handle, 'VisibilityTimeout': t[1]}
+            for t in messages
+        ]
+
+        p_params = {
+            'json': {'Entries': entries},
+            'query': _query_object_encode({'ChangeMessageVisibilityBatchRequestEntry': entries}),
+        }
+
         return self.get_object(
-            'ChangeMessageVisibilityBatch', params, queue.id,
+            'ChangeMessageVisibilityBatch', {}, queue.id,
             verb='POST', callback=callback,
+            protocol_params=p_params,
         )
 
     def get_all_queues(self, prefix='', callback=None):
@@ -272,3 +290,22 @@ class AsyncSQSConnection(AsyncAWSQueryConnection):
         return self.get_status(
             'RemovePermission', {'Label': label}, queue.id, callback=callback,
         )
+
+
+def _query_object_encode(items):
+    params = {}
+    _query_object_encode_part(params, '', items)
+    return {k: v for k, v in params.items()}
+
+
+def _query_object_encode_part(params, prefix, part):
+    dotted = f'{prefix}.' if prefix else prefix
+
+    if isinstance(part, (list, tuple)):
+        for i, item in enumerate(part):
+            _query_object_encode_part(params, f'{dotted}{i + 1}', item)
+    elif isinstance(part, dict):
+        for key, value in part.items():
+            _query_object_encode_part(params, f'{dotted}{key}', value)
+    else:
+        params[prefix] = str(part)

--- a/kombu/asynchronous/aws/sqs/connection.py
+++ b/kombu/asynchronous/aws/sqs/connection.py
@@ -20,13 +20,17 @@ __all__ = ('AsyncSQSConnection',)
 class AsyncSQSConnection(AsyncAWSQueryConnection):
     """Async SQS Connection."""
 
-    def __init__(self, sqs_connection, debug=0, region=None, **kwargs):
+    def __init__(self, sqs_connection, debug=0, region=None, fetch_message_attributes=None, **kwargs):
         if boto3 is None:
             raise ImportError('boto3 is not installed')
         super().__init__(
             sqs_connection,
             region_name=region, debug=debug,
             **kwargs
+        )
+        self.fetch_message_attributes = (
+            fetch_message_attributes if fetch_message_attributes is not None
+            else ["ApproximateReceiveCount"]
         )
 
     def _create_query_request(self, operation, params, queue_url, method):
@@ -147,17 +151,18 @@ class AsyncSQSConnection(AsyncAWSQueryConnection):
 
     def receive_message(
         self, queue, queue_url, number_messages=1, visibility_timeout=None,
-        attributes=('ApproximateReceiveCount',), wait_time_seconds=None,
+        attributes=None, wait_time_seconds=None,
         callback=None
     ):
         params = {'MaxNumberOfMessages': number_messages}
         proto_params = {'query': {}, 'json': {}}
+        attrs = attributes if attributes is not None else self.fetch_message_attributes
 
         if visibility_timeout:
             params['VisibilityTimeout'] = visibility_timeout
-        if attributes:
-            proto_params['json'].update({'AttributeNames': list(attributes)})
-            proto_params['query'].update(_query_object_encode({'AttributeName': list(attributes)}))
+        if attrs:
+            proto_params['json'].update({'AttributeNames': list(attrs)})
+            proto_params['query'].update(_query_object_encode({'AttributeName': list(attrs)}))
         if wait_time_seconds is not None:
             params['WaitTimeSeconds'] = wait_time_seconds
 

--- a/kombu/asynchronous/aws/sqs/connection.py
+++ b/kombu/asynchronous/aws/sqs/connection.py
@@ -88,7 +88,7 @@ class AsyncSQSConnection(AsyncAWSQueryConnection):
         implementation of make_request for SQS. More information on this can
         be found in: https://github.com/celery/kombu/pull/1807.
 
-        protocol_params: Optional[dict[str, dict] of per-protocol additional parameters.
+        protocol_params: Optional[dict[str, dict]] of per-protocol additional parameters.
             Supported for the SQS query to json protocol transition.
         """
         signer = self.sqs_connection._request_signer

--- a/t/unit/asynchronous/aws/sqs/test_connection.py
+++ b/t/unit/asynchronous/aws/sqs/test_connection.py
@@ -4,7 +4,7 @@ import json
 from unittest.mock import MagicMock, Mock
 
 from kombu.asynchronous.aws.ext import AWSRequest, boto3
-from kombu.asynchronous.aws.sqs.connection import AsyncSQSConnection
+from kombu.asynchronous.aws.sqs.connection import _query_object_encode, AsyncSQSConnection
 from kombu.asynchronous.aws.sqs.message import AsyncMessage
 from kombu.asynchronous.aws.sqs.queue import AsyncQueue
 from kombu.utils.uuid import uuid
@@ -97,7 +97,7 @@ class test_AsyncSQSConnection(AWSCase):
         method = 'POST'
         params = {
             'MaxNumberOfMessages': 10,
-            'AttributeName.1': 'ApproximateReceiveCount',
+            'AttributeNames': ['ApproximateReceiveCount'],
             'WaitTimeSeconds': 20
         }
         queue_url = f'{SQS_URL}/123456789012/celery-test'
@@ -137,14 +137,21 @@ class test_AsyncSQSConnection(AWSCase):
         operation = 'ReceiveMessage',
         params = {
             'MaxNumberOfMessages': 10,
-            'AttributeName.1': 'ApproximateReceiveCount',
+
             'WaitTimeSeconds': 20
+        }
+        pparams = {
+            'json': {'AttributeNames': ['ApproximateReceiveCount']},
+            'query': {'AttributeName.1': 'ApproximateReceiveCount'},
         }
         queue_url = f'{SQS_URL}/123456789012/celery-test'
         verb = 'POST'
-        self.x.make_request(operation, params, queue_url, verb)
+
+        expect_params = params | {'AttributeName.1': 'ApproximateReceiveCount'}
+
+        self.x.make_request(operation, params, queue_url, verb, protocol_params=pparams)
         self.x._create_query_request.assert_called_with(
-            operation, params, queue_url, verb
+            operation, expect_params, queue_url, verb
         )
 
     def test_make_request__with_json_protocol(self):
@@ -159,14 +166,20 @@ class test_AsyncSQSConnection(AWSCase):
         operation = 'ReceiveMessage',
         params = {
             'MaxNumberOfMessages': 10,
-            'AttributeName.1': 'ApproximateReceiveCount',
             'WaitTimeSeconds': 20
         }
+        pparams = {
+            'json': {'AttributeNames': ['ApproximateReceiveCount']},
+            'query': {'AttributeName.1': 'ApproximateReceiveCount'},
+        }
+
         queue_url = f'{SQS_URL}/123456789012/celery-test'
         verb = 'POST'
-        self.x.make_request(operation, params, queue_url, verb)
+        expect_params = params | {'AttributeNames': ['ApproximateReceiveCount']}
+
+        self.x.make_request(operation, params, queue_url, verb, protocol_params=pparams)
         self.x._create_json_request.assert_called_with(
-            operation, params, queue_url
+            operation, expect_params, queue_url
         )
 
     def test_create_queue(self):
@@ -211,11 +224,12 @@ class test_AsyncSQSConnection(AWSCase):
             queue, 'Expires', '3600', callback=self.callback,
         )
         self.x.get_status.assert_called_with(
-            'SetQueueAttribute', {
-                'Attribute.Name': 'Expires',
-                'Attribute.Value': '3600',
+            'SetQueueAttribute',
+            {}, queue.id, callback=self.callback,
+            protocol_params={
+                'json': {'Attributes': {'Expires': '3600'}},
+                'query': {'Attribute.Name': 'Expires', 'Attribute.Value': '3600'},
             },
-            queue.id, callback=self.callback,
         )
 
     def test_receive_message(self):
@@ -229,11 +243,14 @@ class test_AsyncSQSConnection(AWSCase):
         self.x.get_list.assert_called_with(
             'ReceiveMessage', {
                 'MaxNumberOfMessages': 4,
-                'AttributeName.1': 'ApproximateReceiveCount'
             },
             [('Message', AsyncMessage)],
             'http://aws.com', callback=self.callback,
             parent=queue,
+            protocol_params={
+                'json': {'AttributeNames': ['ApproximateReceiveCount']},
+                'query': {'AttributeName.1': 'ApproximateReceiveCount'},
+            },
         )
 
     def test_receive_message__with_visibility_timeout(self):
@@ -249,11 +266,14 @@ class test_AsyncSQSConnection(AWSCase):
             'ReceiveMessage', {
                 'MaxNumberOfMessages': 4,
                 'VisibilityTimeout': 3666,
-                'AttributeName.1': 'ApproximateReceiveCount',
             },
             [('Message', AsyncMessage)],
             'http://aws.com', callback=self.callback,
             parent=queue,
+            protocol_params={
+                'json': {'AttributeNames': ['ApproximateReceiveCount']},
+                'query': {'AttributeName.1': 'ApproximateReceiveCount'},
+            },
         )
 
     def test_receive_message__with_wait_time_seconds(self):
@@ -269,11 +289,14 @@ class test_AsyncSQSConnection(AWSCase):
             'ReceiveMessage', {
                 'MaxNumberOfMessages': 4,
                 'WaitTimeSeconds': 303,
-                'AttributeName.1': 'ApproximateReceiveCount',
             },
             [('Message', AsyncMessage)],
             'http://aws.com', callback=self.callback,
             parent=queue,
+            protocol_params={
+                'json': {'AttributeNames': ['ApproximateReceiveCount']},
+                'query': {'AttributeName.1': 'ApproximateReceiveCount'},
+            },
         )
 
     def test_receive_message__with_attributes(self):
@@ -287,13 +310,15 @@ class test_AsyncSQSConnection(AWSCase):
         )
         self.x.get_list.assert_called_with(
             'ReceiveMessage', {
-                'AttributeName.1': 'foo',
-                'AttributeName.2': 'bar',
                 'MaxNumberOfMessages': 4,
             },
             [('Message', AsyncMessage)],
             'http://aws.com', callback=self.callback,
             parent=queue,
+            protocol_params={
+                'json': {'AttributeNames': ['foo', 'bar']},
+                'query': {'AttributeName.1': 'foo', 'AttributeName.2': 'bar'},
+            },
         )
 
     def MockMessage(self, id=None, receipt_handle=None, body=None):
@@ -328,13 +353,17 @@ class test_AsyncSQSConnection(AWSCase):
                     self.MockMessage('2', 'r2')]
         self.x.delete_message_batch(queue, messages, callback=self.callback)
         self.x.get_object.assert_called_with(
-            'DeleteMessageBatch', {
-                'DeleteMessageBatchRequestEntry.1.Id': '1',
-                'DeleteMessageBatchRequestEntry.1.ReceiptHandle': 'r1',
-                'DeleteMessageBatchRequestEntry.2.Id': '2',
-                'DeleteMessageBatchRequestEntry.2.ReceiptHandle': 'r2',
-            },
+            'DeleteMessageBatch', {},
             queue.id, verb='POST', callback=self.callback,
+            protocol_params={
+                'json': {'Entries': [{'Id': '1', 'ReceiptHandle': 'r1'}, {'Id': '2', 'ReceiptHandle': 'r2'}]},
+                'query': {
+                    'DeleteMessageBatchRequestEntry.1.Id': '1',
+                    'DeleteMessageBatchRequestEntry.1.ReceiptHandle': 'r1',
+                    'DeleteMessageBatchRequestEntry.2.Id': '2',
+                    'DeleteMessageBatchRequestEntry.2.ReceiptHandle': 'r2',
+                },
+            },
         )
 
     def test_send_message(self):
@@ -398,19 +427,25 @@ class test_AsyncSQSConnection(AWSCase):
             queue, messages, callback=self.callback,
         )
 
-        def preamble(n):
-            return '.'.join(['ChangeMessageVisibilityBatchRequestEntry', n])
-
-        self.x.get_object.assert_called_with(
-            'ChangeMessageVisibilityBatch', {
-                preamble('1.Id'): '1',
-                preamble('1.ReceiptHandle'): 'r1',
-                preamble('1.VisibilityTimeout'): 303,
-                preamble('2.Id'): '2',
-                preamble('2.ReceiptHandle'): 'r2',
-                preamble('2.VisibilityTimeout'): 909,
-            },
+        self.x.get_object.assert_called_once_with(
+            'ChangeMessageVisibilityBatch', {},
             queue.id, verb='POST', callback=self.callback,
+            protocol_params={
+                'json': {
+                    'Entries': [
+                        {'Id': '1', 'ReceiptHandle': 'r1', 'VisibilityTimeout': 303},
+                        {'Id': '2', 'ReceiptHandle': 'r2', 'VisibilityTimeout': 909},
+                    ],
+                },
+                'query': {
+                    'ChangeMessageVisibilityBatchRequestEntry.1.Id': '1',
+                    'ChangeMessageVisibilityBatchRequestEntry.1.ReceiptHandle': 'r1',
+                    'ChangeMessageVisibilityBatchRequestEntry.1.VisibilityTimeout': '303',
+                    'ChangeMessageVisibilityBatchRequestEntry.2.Id': '2',
+                    'ChangeMessageVisibilityBatchRequestEntry.2.ReceiptHandle': 'r2',
+                    'ChangeMessageVisibilityBatchRequestEntry.2.VisibilityTimeout': '909',
+                },
+            },
         )
 
     def test_get_all_queues(self):
@@ -480,3 +515,20 @@ class test_AsyncSQSConnection(AWSCase):
             'RemovePermission', {'Label': 'label'}, queue.id,
             callback=self.callback,
         )
+
+    def test_query_protocol_encoding(self):
+        assert _query_object_encode({}) == {}
+
+        assert _query_object_encode({'Simple': 'String'}) == {'Simple': 'String'}
+
+        assert _query_object_encode({'NumbersToString': 123}) == {'NumbersToString': '123'}
+
+        assert _query_object_encode({'AttributeName': ['A', 'B']}) == {
+            'AttributeName.1': 'A',
+            'AttributeName.2': 'B',
+        }
+
+        assert _query_object_encode({'Grandparent': [{'Parent': {'Child': '1', 'Sibling': 2}}]}) == {
+            'Grandparent.1.Parent.Child': '1',
+            'Grandparent.1.Parent.Sibling': '2',
+        }

--- a/t/unit/transport/test_SQS.py
+++ b/t/unit/transport/test_SQS.py
@@ -486,12 +486,15 @@ class test_Channel:
         assert get_list_args[0] == 'ReceiveMessage'
         assert get_list_args[1] == {
             'MaxNumberOfMessages': SQS.SQS_MAX_MESSAGES,
-            'AttributeName.1': 'ApproximateReceiveCount',
             'WaitTimeSeconds': self.channel.wait_time_seconds,
         }
         assert get_list_args[3] == \
             self.channel.sqs().get_queue_url(self.queue_name).url
         assert get_list_kwargs['parent'] == self.queue_name
+        assert get_list_kwargs['protocol_params'] == {
+            'json': {'AttributeNames': ['ApproximateReceiveCount']},
+            'query': {'AttributeName.1': 'ApproximateReceiveCount'},
+        }
 
     def test_drain_events_with_empty_list(self):
         def mock_can_consume():

--- a/t/unit/transport/test_SQS.py
+++ b/t/unit/transport/test_SQS.py
@@ -496,6 +496,11 @@ class test_Channel:
             'query': {'AttributeName.1': 'ApproximateReceiveCount'},
         }
 
+    def test_fetch_message_attributes(self):
+        self.connection.transport_options['fetch_message_attributes'] = ["Attribute1", "Attribute2"]
+        async_sqs_conn = self.channel.asynsqs(self.queue_name)
+        assert async_sqs_conn.fetch_message_attributes == ['Attribute1', 'Attribute2']
+
     def test_drain_events_with_empty_list(self):
         def mock_can_consume():
             return False


### PR DESCRIPTION
Adds support for consuming botocore SQS `json` models in the SQS async code. This only affects consumer code.

Several parameters are supplied incorrectly as they have changed in the `query` to `json` botocore change. If you have a newer version of botocore, you will get the `json` service model instead of the old `query` model. I found several places where kombu was generating calls to the new `json` API  (indicated by the x-amz-json-1.0 content-type) but providing parameter names consistent with the `query` protocol.

This PR makes kombu aware of both the `json` and `query` protocol query names and provide them both. When the AWS request is later constructed from the service model, we apply protocol-specific and common parameters. Unfortunately, AWS has not maintained consistency in the parameter names, so I manually reviewed each API call and supplied both.

The only things that broke were compound data types for ReceiveMessage -- those are attribute names. Other things did not break because the code path for post-process message deletion is through the synchronous branch, which uses standard boto and not the async request builder (`kombu.transport.SQS.Channel.basic_ack`). Nevertheless, I fixed all the parameters in the async client.

Logged request after PR (note new usage of `AttributeNames` instead of `AttributeName.1`):

```http
POST https://sqs.us-west-2.amazonaws.com 200
Content-Type: application/x-amz-json-1.0
X-Amz-Target: AmazonSQS.ReceiveMessage
X-Amz-Date: 20250115T190022Z
Authorization: AWS4-HMAC-SHA256 XXX
Content-Length: 177
User-Agent: Mozilla/5.0 (compatible; urllib3)
Accept-Encoding: gzip,deflate

{"MaxNumberOfMessages": 2, "WaitTimeSeconds": 20, "AttributeNames": ["ApproximateReceiveCount"], "QueueUrl": "https://sqs.us-west-2.amazonaws.com/XXX/identity-hunterq"}



200
x-amzn-RequestId: 05a8dffc-0ce3-5cc7-85c0-bffe04e5c2b2
Date: Wed, 15 Jan 2025 19:00:42 GMT
Content-Type: application/x-amz-json-1.0
Content-Length: 2
connection: keep-alive

{}

```

This code supporting both protocols can be cleaned up if Kombu is willing to require `botocore>=1.34.90`, which was released in April 2024 (boto/botocore/pull/3165). It can take quite a while to move forward the boto3/botocore/moto ecosystem, so Kombu may want to give consumers some time before dropping old botocores. Either way, this PR would be required.

---

As I fixed this to get support for AttributeNames back, I also added support for customizing fetched attributes via `transport_options.fetch_message_attributes`. Now you can supply `["All"]` to get better diagnostics from SQS. I added documentation for this.